### PR TITLE
Cleaned up monad syntax

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,20 +10,13 @@ import Menu.VoltageMenu
 import Menu.CurrentMenu
 
 ohms_law :: String -> IO ()
-ohms_law "r" = do
-    resistanceMenu
-ohms_law "v" = do
-    voltageMenu
-ohms_law "i" = do
-    currentMenu
-ohms_law "p" = do
-    printf "Power is coming soon\n"
-ohms_law _  = do
-    printf "%s" "Unrecognised input, for example, press the 'r' key to calculate resistance...\n"
+ohms_law "r" = resistanceMenu
+ohms_law "v" = voltageMenu
+ohms_law "i" = currentMenu
+ohms_law "p" = printf "Power is coming soon\n"
+ohms_law _  = printf "%s" "Unrecognised input, for example, press the 'r' key to calculate resistance...\n"
 
-eleculator = do 
-    opt <- getLine
-    ohms_law opt
+eleculator = getLine >>= (\opt -> ohms_law opt)
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,5 +20,6 @@ eleculator = getLine >>= (\opt -> ohms_law opt)
 
 main :: IO ()
 main = do
+    hSetBuffering stdout NoBuffering
     putStrLn "\nWelcome to Eleculator!\nCalculate, compute and understand electrical circuits.\n\nMenu (type the letter to enter the program):\n\tOhms law:\n\t\tr - Calculate resistance\n\t\tv - Calculate voltage\n\t\ti - Calculate amps\n\t\tp - Calculate watts (power)"
     forever eleculator

--- a/src/Menu/CurrentMenu.hs
+++ b/src/Menu/CurrentMenu.hs
@@ -6,7 +6,6 @@ import OhmsLaw
 import Text.Printf
 
 currentMenu = do
-    hSetBuffering stdout NoBuffering
     putStr "What is your voltage (V)? "
     v <- getLine
     putStr "What is your resistance (R)? "

--- a/src/Menu/ResistanceMenu.hs
+++ b/src/Menu/ResistanceMenu.hs
@@ -5,7 +5,6 @@ import OhmsLaw
 import Text.Printf
 
 resistanceMenu = do 
-    hSetBuffering stdout NoBuffering
     putStr "What is your current (I)? "
     i <- getLine
     putStr "What is your voltage (V)? "

--- a/src/Menu/VoltageMenu.hs
+++ b/src/Menu/VoltageMenu.hs
@@ -5,7 +5,6 @@ import OhmsLaw
 import Text.Printf
 
 voltageMenu = do 
-    hSetBuffering stdout NoBuffering
     putStr "What is your current (I)? "
     i <- getLine
     putStr "What is your resistance (R)? "


### PR DESCRIPTION
Just a small tidy up.

```Haskell
eleculator = getLine >>= (\opt -> ohms_law opt)
```

is equivalent to 

```Haskell
eleculator = do
    opt <- getLine
    ohms_law opt
````

The second one is syntactic sugar for the first one.

-------
Also removed the `do` statements when they were not needed to make the code smaller.

-------
Also moved the buffering instruction to main to make the code smaller.